### PR TITLE
Renames: `@bind => @own`, `Bound => Owned`, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BorrowChecker"
 uuid = "7bdcaa52-c310-4bb0-bf54-d941056ed284"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.0.5"
+version = "0.0.6"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -15,13 +15,13 @@ include("experimental.jl")
 
 #! format: off
 using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError
-using .TypesModule: Bound, BoundMut, Borrowed, BorrowedMut, LazyAccessor
-using .MacrosModule: @bind, @move, @ref, @take, @take!, @set, @lifetime, @clone
+using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor
+using .MacrosModule: @own, @move, @ref, @take, @take!, @set, @lifetime, @clone
 using .PreferencesModule: disable_borrow_checker!
 
 export MovedError, BorrowError, BorrowRuleError, SymbolMismatchError, ExpiredError
-export Bound, BoundMut, Borrowed, BorrowedMut, LazyAccessor
-export @bind, @move, @ref, @take, @take!, @set, @lifetime, @clone
+export Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor
+export @own, @move, @ref, @take, @take!, @set, @lifetime, @clone
 
 # Not exported but still available
 using .StaticTraitModule: is_static

--- a/test/FakeModule/src/FakeModule.jl
+++ b/test/FakeModule/src/FakeModule.jl
@@ -5,12 +5,12 @@ using BorrowChecker.Experimental: @managed
 using Test
 
 function test()
-    @bind x = Ref(1)
+    @own x = Ref(1)
     @test x isa Base.RefValue{Int}
-    @test !(x isa Bound{Base.RefValue{Int}})
+    @test !(x isa Owned{Base.RefValue{Int}})
     @move y = x
     @test y isa Base.RefValue{Int}
-    @test !(y isa Bound)
+    @test !(y isa Owned)
     # Since borrow checker is disabled, x should still be accessible
     @test x[] == 1
     # @take! should just return the value directly
@@ -19,11 +19,11 @@ function test()
     @test x[] == 1
 
     # Test @set
-    @bind :mut z = 1
+    @own :mut z = 1
     @set z = 2
     @test z == 2
     @test z isa Int
-    @test !(z isa BoundMut{Int})
+    @test !(z isa OwnedMut{Int})
 
     # Test @lifetime and @ref
     @lifetime l begin
@@ -42,10 +42,10 @@ function test()
         return x + 1
     end
 
-    @bind w = 42
+    @own w = 42
     # When enabled, managed() would automatically convert w to raw Int,
     # but when disabled it should fail since w is passed as-is
-    @bind result = @managed expects_raw_int(w)
+    @own result = @managed expects_raw_int(w)
     @test result == 43  # Function runs normally since w is just a raw Int
     @test w == 42  # w is not moved since managed() is disabled
 end

--- a/test/reference_tests.jl
+++ b/test/reference_tests.jl
@@ -4,7 +4,7 @@ using BorrowChecker
 @testitem "Immutable References" begin
     using BorrowChecker: is_moved
 
-    @bind :mut x = [1, 2, 3]
+    @own :mut x = [1, 2, 3]
     @lifetime lt begin
         @ref lt ref = x
         @test ref == [1, 2, 3]  # Can read through reference
@@ -16,7 +16,7 @@ using BorrowChecker
 end
 
 @testitem "Expired references" begin
-    @bind x = [42]
+    @own x = [42]
     y = Any[]
     @lifetime lt begin
         @ref lt ref = x
@@ -35,7 +35,7 @@ end
 end
 
 @testitem "Lifetime nesting restrictions" begin
-    @bind arr = [10, 20, 30]
+    @own arr = [10, 20, 30]
     @lifetime outerLT begin
         @ref outerLT refA = arr
         @lifetime innerLT begin
@@ -55,8 +55,8 @@ end
         x::Int
         y::Int
     end
-    @bind p = Point(1, 2)
-    @test p isa Bound{Point}
+    @own p = Point(1, 2)
+    @test p isa Owned{Point}
     @lifetime lt begin
         @ref lt ref_p = p
         @test ref_p isa Borrowed{Point}
@@ -68,7 +68,7 @@ end
         @test_throws BorrowRuleError ref_p.x = 10  # Can't modify properties
     end
     @test get_immutable_borrows(p) == 0
-    @bind :mut mp = Point(1, 2)
+    @own :mut mp = Point(1, 2)
     @lifetime lt begin
         @ref lt :mut mut_ref_p = mp
         @test mut_ref_p.x == 1
@@ -76,7 +76,7 @@ end
 end
 
 @testitem "Mutable Property Access" begin
-    @bind :mut y = [1, 2, 3]
+    @own :mut y = [1, 2, 3]
     @lifetime lt begin
         @ref lt :mut mut_ref = y
         @test mut_ref == [1, 2, 3]  # Can read through reference
@@ -90,7 +90,7 @@ end
 end
 
 @testitem "Referencing moved values" begin
-    @bind z = [1, 2, 3]
+    @own z = [1, 2, 3]
     @move w = z
     @lifetime lt begin
         @test_throws MovedError @ref lt d = z
@@ -102,7 +102,7 @@ end
     using BorrowChecker: get_immutable_borrows, get_mutable_borrows
 
     # Test multiple immutable references
-    @bind x = [1, 2, 3]
+    @own x = [1, 2, 3]
     @lifetime lt begin
         @ref lt ref1 = x
         @ref lt ref2 = x
@@ -116,8 +116,8 @@ end
     @test get_immutable_borrows(x) == 0  # All borrows cleaned up
 
     # Test mutable reference blocks
-    @bind :mut y = [1, 2, 3]
-    @bind :mut z = [4, 5, 6]
+    @own :mut y = [1, 2, 3]
+    @own :mut z = [4, 5, 6]
     @lifetime lt begin
         @ref lt :mut mut_ref1 = y
         # Can't create another mutable reference to y
@@ -136,8 +136,8 @@ end
     @test z == [4, 5, 6, 7]
 
     # Test mixing mutable and immutable references to different variables
-    @bind :mut a = [1, 2, 3]
-    @bind b = [4, 5, 6]
+    @own :mut a = [1, 2, 3]
+    @own b = [4, 5, 6]
     @lifetime lt begin
         @ref lt :mut mut_ref = a
         @ref lt imm_ref = b
@@ -153,7 +153,7 @@ end
     using BorrowChecker: get_mutable_borrows
 
     # Test lifetime with let block
-    @bind :mut outer = [1, 2, 3]
+    @own :mut outer = [1, 2, 3]
 
     @lifetime lt let
         @ref lt :mut inner = outer
@@ -167,7 +167,7 @@ end
 end
 
 @testitem "Prevents write on mutable array when referenced" begin
-    @bind :mut x = [1, 2, 3]
+    @own :mut x = [1, 2, 3]
     @lifetime lt begin
         @ref lt ref = x
         @test_throws BorrowRuleError x[1] = 5
@@ -181,7 +181,7 @@ end
         x::Vector{Int}
     end
 
-    @bind :mut c = Container([1, 2, 3])
+    @own :mut c = Container([1, 2, 3])
     c.x[1] = 4
     @test c.x == [4, 2, 3]
 


### PR DESCRIPTION
This is to get compatibility with Pluto.jl 🫡 

Fixes #2 by @pankgeorg

Let me know if this works out-of-the-box now or there's any other macro conflicts?
