### PR TITLE
More aliasing detection operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BorrowChecker"
 uuid = "7bdcaa52-c310-4bb0-bf54-d941056ed284"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
 
 [deps]

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -14,7 +14,7 @@ include("overloads.jl")
 include("disambiguations.jl")
 
 #! format: off
-using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError
+using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError, AliasedReturnError
 using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
 using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut
 

--- a/src/static_trait.jl
+++ b/src/static_trait.jl
@@ -42,4 +42,13 @@ is_static(::Type{Module}) = true
 
 is_static(::T) where {T} = is_static(T)
 
+"""
+    is_static_elements(x)
+
+Tests if both the keys and values for a given collection
+type are `is_static`.
+"""
+is_static_elements(::Type{T}) where {T} = is_static(eltype(T))
+is_static_elements(::T) where {T} = is_static_elements(T)
+
 end

--- a/test/feature_tests.jl
+++ b/test/feature_tests.jl
@@ -561,6 +561,8 @@ end
     end
 end
 @testitem "Dictionary & LazyAccessor coverage" begin
+    using BorrowChecker: AliasedReturnError
+
     @own :mut d = Dict(:a => 1, :b => 2)
     @test haskey(d, :a)
     @test !haskey(d, :c)
@@ -576,7 +578,7 @@ end
 
     # Non-isbits key => triggers throw(...) => ErrorException
     @own :mut d2 = Dict([1] => 10, [2] => 20)
-    @test_throws ErrorException keys(d2)
+    @test_throws AliasedReturnError keys(d2)
 
     # LazyAccessor setindex! coverage
     @own :mut arr2d = [[10, 20], [30, 40]]
@@ -644,12 +646,11 @@ end
 end
 
 @testitem "Dictionary Error Paths" begin
+    using BorrowChecker: AliasedReturnError
+
     # Test error on non-isbits keys
     @own :mut d = Dict([1, 2] => 10)  # Vector{Int} is non-isbits
-    @test_throws(
-        "Refusing to return result of keys with a non-isbits element type, because this can result in unintended aliasing with the original array. Use `keys(@take!(d))` instead.",
-        keys(d)
-    )
+    @test_throws AliasedReturnError keys(d)
 
     # Test error on type conversion
     @own :mut d2 = Dict(1 => 2)
@@ -657,6 +658,27 @@ end
         @ref ~lt :mut ref = d2
         @test_throws MethodError ref[1] = "string"  # Can't convert String to Int
     end
+
+    # Test AliasedReturnError message formatting
+    err = try
+        @own vec_dict = Dict(1 => [1], 2 => [2])
+        pairs(vec_dict)
+    catch e
+        e
+    end
+
+    # Verify error message contains the right components
+    err_msg = sprint(io -> showerror(io, err))
+    @test occursin("Refusing to return result of ", err_msg)
+    @test occursin("contains mutable elements", err_msg)
+    @test occursin("unintended aliasing", err_msg)
+    @test occursin("@take!(...)", err_msg)
+
+    # Test AliasedReturnError constructors
+    e1 = AliasedReturnError(keys, Dict{Int,Vector{Int}})
+    @test e1.arg_count == 1
+    e2 = AliasedReturnError(merge, Dict{Int,Vector{Int}}, 2)
+    @test e2.arg_count == 2
 end
 
 @testitem "String Operation Errors" begin
@@ -714,6 +736,8 @@ end
 end
 
 @testitem "Macro Error Paths" begin
+    using BorrowChecker: AliasedReturnError
+
     # Test error on invalid first argument to @clone
     @test_throws LoadError @eval @clone :invalid x = 42
 
@@ -741,7 +765,7 @@ end
     @own :mut arr = [NonIsBits([1])]
     @lifetime lt begin
         @ref ~lt :mut ref = arr
-        @test_throws ErrorException collect(ref)  # Non-isbits collection
+        @test_throws AliasedReturnError collect(ref)  # Non-isbits collection
         @test_throws ErrorException first(ref)    # Non-isbits element
     end
 
@@ -826,18 +850,19 @@ end
 end
 
 @testitem "Collection Operation Errors" begin
-    # Test collection operation errors
     mutable struct NonIsBits
         x::Int
     end
 
     @own :mut arr = [NonIsBits(1)]
-    @test_throws "Use `@own for var in iter` (moves) or `@ref for var in iter` (borrows) instead" collect(
-        arr
-    )
+    @test_throws "Use `@own for var in iter` (moves) or `@ref for var in iter` (borrows) instead" [
+        x for x in arr
+    ]
 end
 
 @testitem "Dictionary Operation Errors" begin
+    using BorrowChecker: AliasedReturnError
+
     mutable struct NonIsBits
         x::Int
     end
@@ -847,16 +872,19 @@ end
     @own :mut dictref = Ref(Dict(NonIsBits(1) => 10))
     @lifetime lt begin
         @ref ~lt :mut ref = dict
-        @test_throws(
-            "Refusing to return result of keys with a non-isbits element type, because this can result in unintended aliasing with the original array. Use `keys(@take!(d))` instead.",
+        # Capture the error and verify its message
+        err = try
             keys(ref)
-        )
+        catch e
+            e
+        end
+        @test err isa AliasedReturnError
+        err_msg = sprint(io -> showerror(io, err))
+        @test occursin("Refusing to return result of keys", err_msg)
+        @test occursin("Base.KeySet", err_msg)
 
         @ref ~lt :mut ref2 = dictref
-        @test_throws(
-            "Refusing to return result of keys with a non-isbits element type, because this can result in unintended aliasing with the original array. Use `keys(@take!(d))` instead.",
-            keys(ref2[])
-        )
+        @test_throws AliasedReturnError keys(ref2[])
     end
 
     # Test dictionary operation errors
@@ -1234,7 +1262,7 @@ end
 end
 
 @testitem "Collection operations" begin
-    using BorrowChecker: is_moved
+    using BorrowChecker: is_moved, AliasedReturnError
     using Random: shuffle!, MersenneTwister
 
     # Test non-mutating operations that are safe to return
@@ -1275,15 +1303,9 @@ end
 
     # Test operations that should error on non-isbits return
     @own :mut strings = [["b"], ["c"], ["a"]]
-    @test_throws(
-        "Refusing to return result of unique with a non-isbits element type",
-        unique(strings)
-    )
-    @test_throws(
-        "because this can result in unintended aliasing with the original array. Use `sort(@take!(d))` instead.",
-        sort(strings)
-    )
-    @test_throws "Use `reverse(@take!(d))` instead." reverse(strings)
+    @test_throws AliasedReturnError unique(strings)
+    @test_throws AliasedReturnError sort(strings)
+    @test_throws AliasedReturnError reverse(strings)
     @test sort!(strings) === nothing
     @test strings == [["a"], ["b"], ["c"]]
     @test shuffle!(strings) === nothing

--- a/test/ownership_tests.jl
+++ b/test/ownership_tests.jl
@@ -96,6 +96,7 @@ end
 
 @testitem "mutability check works" begin
     using BorrowChecker: is_static
+    using BorrowChecker.StaticTraitModule: is_static_elements
 
     @test is_static(1)
     @test is_static(Int)
@@ -144,6 +145,27 @@ end
     end
     @test isbitstype(Container3)
     @test is_static(Container3)
+
+    # Test is_static_elements with different collection types
+    # Collection with static elements
+    @test is_static_elements(Vector{Int})
+    @test is_static_elements(Dict{Int,String})
+    @test is_static_elements(Set{Float64})
+    @test is_static_elements([1, 2, 3])
+    @test is_static_elements(Dict(1 => "a", 2 => "b"))
+    @test is_static_elements(Set([1.0, 2.0]))
+
+    # Collections with non-static elements
+    @test !is_static_elements(Vector{Vector{Int}})
+    @test !is_static_elements(Dict{Int,Vector{Int}})
+    @test !is_static_elements(Set{Dict{Int,Int}})
+    @test !is_static_elements([[1], [2]])
+    @test !is_static_elements(Dict(1 => [1, 2], 2 => [3, 4]))
+    @test !is_static_elements(Set([Dict(1 => 2)]))
+
+    # Mixed cases (non-static either in key or value)
+    @test !is_static_elements(Dict{Vector{Int},Int})
+    @test !is_static_elements(Dict{Int,Vector{Int}})
 end
 
 @testitem "Mutability changes through moves" begin


### PR DESCRIPTION
Now we detect aliased return values from the following functions:

- `pairs`
- `collect`
- `union`
- `intersect`
- `setdiff`
- `symdiff`
- `merge`

This also makes the error a proper error type: `AliasedReturnError`