### PR TITLE
Create `@cc`, a closure check macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This is because in BorrowChecker.jl's ownership model, similar to Rust, an owned
 
 ## Ownership Rules
 
-At any given time, an owned object can only be accessed according to one of the following conditions:
+At any given time, an object managed by BorrowChecker.jl can only be accessed in one of the following states:
 
 1. **Direct Ownership:**
     - The object is accessed directly via its owning variable.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,12 @@ CurrentModule = BorrowChecker
 @mut
 ```
 
+## Validation
+
+```@docs
+@cc
+```
+
 ## Types
 
 ```@docs

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -16,11 +16,11 @@ include("disambiguations.jl")
 #! format: off
 using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError, AliasedReturnError
 using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
-using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut
+using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
 
 export MovedError, BorrowError, BorrowRuleError, SymbolMismatchError, ExpiredError
 export Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
-export @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut
+export @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
 
 # Not exported but still available
 using .PreferencesModule: disable_by_default!

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -538,10 +538,10 @@ function _assert_capture_allowed(::Type{T}, var_name::Symbol) where {T}
     if !_check_capture_allowed(T)
         error(
             "The closure function captured a variable `$var_name::$T`. " *
-            "This is disallowed because variable captures of owned and mutable references " *
-            "breaks the rules of the borrow checker. Only immutable references are allowed. " *
-            "To fix this, you should use `@ref` to create an immutable reference to the " *
-            "variable before capturing.",
+            "This is not allowed because capturing owned variables or mutable references " *
+            "violates the rules of the borrow checker. Only capturing immutable references " *
+            "is allowed. You should use `@ref` to create an immutable reference " *
+            "to the variable before capturing.",
         )
     end
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,6 +1,6 @@
 module MacrosModule
 
-using MacroTools: @q, isexpr, splitarg, isdef
+using MacroTools: @q, isexpr, splitarg, isdef, splitdef
 
 using ..TypesModule:
     Owned,
@@ -12,7 +12,8 @@ using ..TypesModule:
     AllWrappers,
     AllOwned,
     AllBorrowed,
-    AsMutable
+    AsMutable,
+    OrLazy
 using ..SemanticsModule:
     request_value,
     mark_moved!,
@@ -485,6 +486,96 @@ Marks a value to be borrowed mutably in a `@bc` macro call.
 macro mut(expr)
     is_borrow_checker_enabled(__module__) || return esc(expr)
     return esc(:($(AsMutable)($expr)))
+end
+
+"""
+    @cc closure_expr
+
+Checks if a closure expression captures variables of disallowed types:
+- Owned{T}
+- OwnedMut{T}
+- BorrowedMut{T}
+- LazyAccessorOf{Union{Owned{T}, OwnedMut{T}, BorrowedMut{T}}}
+
+Only Borrowed{T} and LazyAccessorOf{Borrowed{T}} are allowed to be captured.
+
+# Examples
+
+```julia
+@own x = 1
+@own :mut y = 2
+@lifetime lt begin
+    @ref ~lt z = x
+    @ref ~lt :mut w = y
+    
+    # This will error - captures owned variable
+    bad = @cc () -> x + 1
+    
+    # This is allowed - only captures borrowed variable
+    good = @cc () -> z + 1
+end
+```
+"""
+macro cc(expr)
+    is_borrow_checker_enabled(__module__) || return esc(expr)
+    return esc(_cc(expr))
+end
+
+# Helper functions to check if a variable's type is allowed to be captured using multiple dispatch
+# COV_EXCL_START
+_check_capture_allowed(var_value) = true
+_check_capture_allowed(var_value::OrLazy{Owned}) = false
+_check_capture_allowed(var_value::OrLazy{OwnedMut}) = false
+_check_capture_allowed(var_value::OrLazy{BorrowedMut}) = false
+# COV_EXCL_STOP
+
+function _assert_capture_allowed(var_value, var_name::Symbol)
+    if !_check_capture_allowed(var_value)
+        error(
+            "Closure captures a variable `$var_name::$(typeof(var_value))`, " *
+            "which is a disallowed type for capture. " *
+            "Only immutable references are allowed (see `@ref`).",
+        )
+    end
+end
+
+#! format: off
+_collect_symbols!(symbols, ex::Symbol) = (push!(symbols, ex); nothing)
+_collect_symbols!(symbols, ex::Expr) = foreach(Base.Fix1(_collect_symbols!, symbols), ex.args)
+_collect_symbols!(_, _) = nothing  # COV_EXCL_LINE
+#! format: on
+
+function _cc(expr)
+    fdef = splitdef(expr)
+
+    # Now extract all argument names
+    arg_symbols = Set{Symbol}()
+    all_args = vcat(get(fdef, :args, []), get(fdef, :kwargs, []))
+    for arg in all_args
+        arg_info = splitarg(arg)
+        _collect_symbols!(arg_symbols, arg_info[1])
+    end
+
+    body_symbols = Set{Symbol}()
+    _collect_symbols!(body_symbols, fdef[:body])
+
+    # The captured variables are those in body that aren't arguments
+    possible_captures = setdiff(body_symbols, arg_symbols)
+
+    # Create runtime checks for each captured variable
+    checks = [
+        quote
+            if $(Base).@isdefined($(var))
+                $(_assert_capture_allowed)($(var), $(QuoteNode(var)))
+            end
+        end for var in possible_captures
+    ]
+
+    # Return the original closure if all checks pass
+    return quote
+        $(checks...)
+        $(expr)
+    end
 end
 
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -491,28 +491,28 @@ end
 """
     @cc closure_expr
 
-Checks if a closure expression captures variables of disallowed types:
-- Owned{T}
-- OwnedMut{T}
-- BorrowedMut{T}
-- LazyAccessorOf{Union{Owned{T}, OwnedMut{T}, BorrowedMut{T}}}
+"Closure Check" is a macro that attempts to verify a closure is compatible with the borrow checker.
 
-Only Borrowed{T} and LazyAccessorOf{Borrowed{T}} are allowed to be captured.
+Only immutable references (created with `@ref` and `@bc`) are allowed to be captured;
+all other owned and borrowed variables that are captured will trigger an error.
 
 # Examples
 
 ```julia
 @own x = 1
 @own :mut y = 2
+
 @lifetime lt begin
     @ref ~lt z = x
     @ref ~lt :mut w = y
     
-    # This will error - captures owned variable
+    # These error as the capturing breaks borrowing rules
     bad = @cc () -> x + 1
+    bad2 = @cc () -> w + 1
     
-    # This is allowed - only captures borrowed variable
+    # However, you are allowed to capture immutable references
     good = @cc () -> z + 1
+    # This will not error.
 end
 ```
 """

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,6 +1,6 @@
 module MacrosModule
 
-using MacroTools: @q, isexpr, splitarg, isdef, splitdef
+using MacroTools: @q, isexpr, splitarg, isdef
 
 using ..TypesModule:
     Owned,

--- a/src/types.jl
+++ b/src/types.jl
@@ -310,6 +310,7 @@ const AllMutable{T} = Union{BorrowedMut{T},OwnedMut{T}}
 const AllEager{T} = Union{AllBorrowed{T},AllOwned{T}}
 const AllWrappers{T} = Union{AllEager{T},LazyAccessor{T}}
 const LazyAccessorOf{O} = LazyAccessor{T,P,S,<:O} where {T,P,S}
+const OrLazy{O} = Union{O,LazyAccessorOf{O}}
 
 """
     OrBorrowed{T}


### PR DESCRIPTION
This validates that closures only ever capture immutable references, which avoids breaking the borrowing rules.

```julia
julia> let
           @own :mut x = [1, 2, 3]
           f = @cc (a, b) -> sum(x) + a + b
       end
ERROR: The closure function captured a variable `x::OwnedMut{Vector{Int64}}`.
This is disallowed because variable captures of owned and mutable references
breaks the rules of the borrow checker. Only immutable references are allowed.
To fix this, you should use `@ref` to create an immutable reference to the
variable before capturing.
```

Many thanks to @danielwe and `@Benny` on discourse for helping: https://discourse.julialang.org/t/ann-borrowchecker-jl-a-borrow-checker-for-julia/127897/34?u=milescranmer