### PR TITLE
Create Mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ In essence: You can have many readers (`Borrowed`) **or** one writer (`BorrowedM
 
 ### References and Lifetimes
 
-- `@bc f(args...; kws...)`: This convenience macro automatically creates a lifetime scope for the duration of the function, and sets up borrowing for any owned input arguments.
-    - Use `@mut(arg)` to mark an input as mutable.
 - `@lifetime lt begin ... end`: Create a scope for references whose lifetimes `lt` are the duration of the block
 - `@ref ~lt [:mut] var = value`: Create a reference, for the duration of `lt`, to owned value `value` and assign it to `var` (mutable if `:mut` is specified)
   - These are `Borrowed{T}` and `BorrowedMut{T}` objects, respectively. Use these in the signature of any function you wish to make compatible with references. In the signature you can use `OrBorrowed{T}` and `OrBorrowedMut{T}` to also allow regular `T`.
+- `Mutex(value)`: Creates a thread-safe container for `value`. Mutexes manage lifetimes implicitly during locks and do not need `@own`.
+  - Use `lock(m)` to acquire the lock, `@ref ~m [:mut] var = m[]` to create a reference to the value inside the mutex, and `unlock(m)` to release the lock.
+- `@bc f(args...; kws...)`: This convenience macro automatically creates a lifetime scope for the duration of the function, and sets up borrowing for any owned input arguments.
+  - Use `@mut(arg)` to mark an input as mutable.
 
 ### Validation
 
@@ -502,7 +504,7 @@ way to handle the majority of borrowing patterns. You can freely mix owned, borr
 
 </details>
 
-### Safe Multi-threading with `Mutex`
+### Safe multi-threading with `Mutex`
 
 <details>
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,6 +19,7 @@ CurrentModule = BorrowChecker
 ```@docs
 @lifetime
 @ref
+Mutex
 @bc
 @mut
 ```

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -12,21 +12,25 @@ include("semantics.jl")
 include("macros.jl")
 include("overloads.jl")
 include("disambiguations.jl")
+include("mutex.jl")
 
 #! format: off
 using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError, AliasedReturnError
 using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
 using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+using .MutexModule: Mutex
 
 export MovedError, BorrowError, BorrowRuleError, SymbolMismatchError, ExpiredError
 export Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
 export @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+export Mutex
 
 # Not exported but still available
 using .PreferencesModule: disable_by_default!
 using .StaticTraitModule: is_static
 using .TypesModule: AsMutable, Lifetime, LazyAccessorOf, is_moved, get_owner, get_symbol, get_immutable_borrows, get_mutable_borrows
 using .MacrosModule: @spawn
+using .MutexModule: AbstractMutex, MutexGuard
 #! format: on
 
 end

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -139,10 +139,8 @@ end
 Access the mutex for referencing. Must be used inside a lock block and with @ref.
 Throws a `LockNotHeldError` if the current task does not hold the lock.
 """
-function Base.getindex(m::AbstractMutex)
-    get_locked_by(m) !== current_task() && throw(LockNotHeldError())
-    return MutexGuard(m)
-end
+Base.getindex(m::AbstractMutex) = MutexGuard(m)
+# TODO: This MutexGuard shouldn't be passed when BorrowChecker is disabled
 
 # Overload ref for MutexGuard to create proper references
 function ref(

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -1,8 +1,7 @@
 module MutexModule
 
 using ..ErrorsModule: BorrowRuleError
-using ..TypesModule:
-    Owned, OwnedMut, AbstractOwned, Lifetime, Borrowed, BorrowedMut, is_mutable
+using ..TypesModule: OwnedMut, Lifetime, Borrowed, BorrowedMut
 using ..SemanticsModule: request_value, validate_mode, cleanup!
 
 import ..SemanticsModule: ref, own
@@ -101,10 +100,6 @@ function Base.lock(m::AbstractMutex)
     m.lifetime = Lifetime()
     return m
 end
-function Base.lock(m_owned::Owned{<:AbstractMutex})
-    validate_mode(m_owned, Val(:read))
-    return lock(request_value(m_owned, Val(:read)))
-end
 
 """
     unlock(m::AbstractMutex)
@@ -118,10 +113,6 @@ function Base.unlock(m::AbstractMutex)
     m.locked_by = nothing
     Base.unlock(get_lock(m))
     return nothing
-end
-function Base.unlock(m_owned::Owned{<:AbstractMutex})
-    validate_mode(m_owned, Val(:read))
-    return unlock(request_value(m_owned, Val(:read)))
 end
 
 """

--- a/src/semantics.jl
+++ b/src/semantics.jl
@@ -143,6 +143,8 @@ function Base.show(io::IO, r::AllBorrowed)
     if is_moved(r)
         # TODO: I don't think we can ever get here?
         print(io, "[reference to moved value]")  # COV_EXCL_LINE
+    elseif is_expired(r)
+        print(io, "[expired reference]")
     else
         constructor = constructorof(typeof(r))
         value = request_value(r, Val(:read))

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -1,0 +1,85 @@
+using TestItems
+using BorrowChecker
+using Base.Threads: @spawn, Condition, ReentrantLock
+
+@testitem "Basic Mutex operations" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    # Create a mutex with a vector
+    m = Mutex([1, 2, 3])
+
+    # Verify we can access the mutex's value inside a lock
+    lock(m) do
+        @ref ~m :mut arr = m[]
+        @test arr == [1, 2, 3]
+        push!(arr, 4)
+    end
+
+    # Verify the value was modified
+    lock(m) do
+        @ref ~m arr = m[]
+        @test arr == [1, 2, 3, 4]
+    end
+
+    # Verify that we can't access the mutex outside a lock
+    @test_throws LockNotHeldError m[]
+end
+
+@testitem "Mutex with borrow checker enabled" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    # Create an owned value first, then move it into the mutex
+    @own data_to_protect = Dict(:counter => 0)
+    m = Mutex(@take!(data_to_protect))
+    # Mutexes don't need to be `@own`ed! They are safe
+    # to pass around as regular Julia objects.
+
+    # Modify the value safely through the mutex
+    Threads.@threads for _ in 1:10
+        lock(m) do
+            @ref ~m :mut dict = m[]
+            dict[:counter] += 1
+        end
+    end
+
+    # Verify the modification worked
+    lock(m) do
+        @ref ~m dict = m[]
+        @test dict[:counter] == 10
+    end
+end
+
+@testitem "Base.@lock syntax" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    m = Mutex([1, 2, 3])
+
+    Base.@lock m begin
+        # Create an immutable reference
+        @ref ~m arr_immut = m[]
+        @test arr_immut == [1, 2, 3]
+
+        # We shouldn't be able to modify the immutable reference
+        @test_throws BorrowRuleError push!(arr_immut, 4)
+    end
+
+    Base.@lock m begin
+        # Create a mutable reference
+        @ref ~m :mut arr_mut = m[]
+        push!(arr_mut, 4)
+        @test arr_mut == [1, 2, 3, 4]
+    end
+end
+
+@testitem "Cannot own a mutex" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: NoOwningMutexError
+
+    m = Mutex([1, 2, 3])
+
+    @test_throws NoOwningMutexError @own m_owned = m
+    @test_throws NoOwningMutexError @own :mut m_owned_mut = m
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("reference_tests.jl")
 include("feature_tests.jl")
 include("integration_tests.jl")
 include("complex_macros.jl")
+include("mutex_tests.jl")
 
 @testitem "Aqua" begin
     using Aqua


### PR DESCRIPTION
This creates a `Mutex` object for safe multi-threading. It's the same semantics as rust.

A Mutex object is safe to pass around in Julia, so there is no need to `@own` it. You access it with immutable and mutable references.

The lifetime of the references will be the duration the lock is held, after which, they will expire.

```julia
julia> m = Mutex([1, 2, 3])
       # ^Regular Julia assignment syntax is fine for Mutexes!
Mutex{Vector{Int64}}([1, 2, 3])

julia> lock(m);

julia> @ref ~m :mut data = m[]
       # ^Mutable reference to the mutex-protected value
BorrowedMut{Vector{Int64},OwnedMut{Vector{Int64}}}([1, 2, 3], :data)

julia> push!(data, 4);

julia> unlock(m);

julia> m
Mutex{Vector{Int64}}([1, 2, 3, 4])
```