### PR TITLE
Create Mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ In essence: You can have many readers (`Borrowed`) **or** one writer (`BorrowedM
 - `@ref ~lt [:mut] var = value`: Create a reference, for the duration of `lt`, to owned value `value` and assign it to `var` (mutable if `:mut` is specified)
   - These are `Borrowed{T}` and `BorrowedMut{T}` objects, respectively. Use these in the signature of any function you wish to make compatible with references. In the signature you can use `OrBorrowed{T}` and `OrBorrowedMut{T}` to also allow regular `T`.
 - `Mutex(value)`: Creates a thread-safe container for `value`. Mutexes manage lifetimes implicitly during locks and do not need `@own`.
-  - Use `lock(m)` to acquire the lock, `@ref ~m [:mut] var = m[]` to create a reference to the value inside the mutex, and `unlock(m)` to release the lock.
+- `@ref_into [:mut] var = mutex[]`: Create a reference to the value inside a mutex.
+  - Use `lock(m)` to acquire the lock, `@ref_into` to create a reference to the value inside the mutex, and `unlock(m)` to release the lock.
 - `@bc f(args...; kws...)`: This convenience macro automatically creates a lifetime scope for the duration of the function, and sets up borrowing for any owned input arguments.
   - Use `@mut(arg)` to mark an input as mutable.
 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ In essence: You can have many readers (`Borrowed`) **or** one writer (`BorrowedM
 
 ### References and Lifetimes
 
-- `@bc f(args...; kws...)`: This convenience macro automatically creates a lifetime scope for the duration of the function, and sets up borrowing for any owned input arguments.
-    - Use `@mut(arg)` to mark an input as mutable.
 - `@lifetime lt begin ... end`: Create a scope for references whose lifetimes `lt` are the duration of the block
 - `@ref ~lt [:mut] var = value`: Create a reference, for the duration of `lt`, to owned value `value` and assign it to `var` (mutable if `:mut` is specified)
   - These are `Borrowed{T}` and `BorrowedMut{T}` objects, respectively. Use these in the signature of any function you wish to make compatible with references. In the signature you can use `OrBorrowed{T}` and `OrBorrowedMut{T}` to also allow regular `T`.
+- `Mutex(value)`: Creates a thread-safe container for `value`. Mutexes manage lifetimes implicitly during locks and do not need `@own`.
+  - Use `lock(m)` to acquire the lock, `@ref ~m [:mut] var = m[]` to create a reference to the value inside the mutex, and `unlock(m)` to release the lock.
+- `@bc f(args...; kws...)`: This convenience macro automatically creates a lifetime scope for the duration of the function, and sets up borrowing for any owned input arguments.
+  - Use `@mut(arg)` to mark an input as mutable.
 
 ### Validation
 
@@ -502,7 +504,7 @@ way to handle the majority of borrowing patterns. You can freely mix owned, borr
 
 </details>
 
-### Safe Multi-threading with `Mutex`
+### Safe multi-threading with `Mutex`
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Mutex{Vector{Int64}}([1, 2, 3])
 
 julia> lock(m);
 
-julia> @ref ~m :mut data = m[]
+julia> @ref_into :mut data = m[]
        # ^Mutable reference to the mutex-protected value
 BorrowedMut{Vector{Int64},OwnedMut{Vector{Int64}}}([1, 2, 3], :data)
 
@@ -549,7 +549,7 @@ Mutex{Dict{String, Int64}}(Dict("count" => 0))
 julia> @sync for i in 1:100
            Threads.@spawn begin
                lock(m) do
-                   @ref ~m :mut d = m[]
+                   @ref_into :mut d = m[]
                    d["count"] += 1
                end
            end
@@ -559,7 +559,7 @@ julia> m
 Mutex{Dict{String, Int64}}(Dict("count" => 100))
 
 julia> d = lock(m) do
-           @ref ~m :mut d = m[]
+           @ref_into :mut d = m[]
            d
        end;
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,6 +19,7 @@ CurrentModule = BorrowChecker
 ```@docs
 @lifetime
 @ref
+Mutex
 @bc
 @mut
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,7 @@ CurrentModule = BorrowChecker
 @lifetime
 @ref
 Mutex
+@ref_into
 @bc
 @mut
 ```

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -30,7 +30,7 @@ using .PreferencesModule: disable_by_default!
 using .StaticTraitModule: is_static
 using .TypesModule: AsMutable, Lifetime, LazyAccessorOf, is_moved, get_owner, get_symbol, get_immutable_borrows, get_mutable_borrows
 using .MacrosModule: @spawn
-using .MutexModule: AbstractMutex, MutexGuard
+using .MutexModule: AbstractMutex, MutexGuard, LockNotHeldError, NoOwningMutexError, MutexGuardValueAccessError
 #! format: on
 
 end

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -9,20 +9,20 @@ include("errors.jl")
 include("types.jl")
 include("preferences.jl")
 include("semantics.jl")
+include("mutex.jl")
 include("macros.jl")
 include("overloads.jl")
 include("disambiguations.jl")
-include("mutex.jl")
 
 #! format: off
 using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError, AliasedReturnError
 using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
-using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+using .MacrosModule: @own, @move, @ref, @ref_into, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
 using .MutexModule: Mutex
 
 export MovedError, BorrowError, BorrowRuleError, SymbolMismatchError, ExpiredError
 export Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
-export @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+export @own, @move, @ref, @ref_into, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
 export Mutex
 
 # Not exported but still available

--- a/src/BorrowChecker.jl
+++ b/src/BorrowChecker.jl
@@ -12,21 +12,25 @@ include("semantics.jl")
 include("macros.jl")
 include("overloads.jl")
 include("disambiguations.jl")
+include("mutex.jl")
 
 #! format: off
 using .ErrorsModule: BorrowError, MovedError, BorrowRuleError, SymbolMismatchError, ExpiredError, AliasedReturnError
 using .TypesModule: Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
 using .MacrosModule: @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+using .MutexModule: Mutex
 
 export MovedError, BorrowError, BorrowRuleError, SymbolMismatchError, ExpiredError
 export Owned, OwnedMut, Borrowed, BorrowedMut, LazyAccessor, OrBorrowed, OrBorrowedMut
 export @own, @move, @ref, @take, @take!, @lifetime, @clone, @bc, @mut, @cc
+export Mutex
 
 # Not exported but still available
 using .PreferencesModule: disable_by_default!
 using .StaticTraitModule: is_static
 using .TypesModule: AsMutable, Lifetime, LazyAccessorOf, is_moved, get_owner, get_symbol, get_immutable_borrows, get_mutable_borrows
 using .MacrosModule: @spawn
+using .MutexModule: AbstractMutex, MutexGuard
 #! format: on
 
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -30,6 +30,7 @@ using ..SemanticsModule:
     cleanup!,
     maybe_ref
 using ..PreferencesModule: is_borrow_checker_enabled
+using ..MutexModule: ref_into
 
 """
     @own [:mut] x = value
@@ -322,6 +323,49 @@ function _ref(lifetime_expr::Expr, expr::Expr, mut::Bool)
     else
         error("@ref requires an assignment expression or for loop")
     end
+end
+
+"""
+    @ref_into [:mut] var = mutex[]
+
+Create a reference to the protected value in a mutex.
+
+If `:mut` is specified, creates a mutable reference.
+Otherwise, creates an immutable reference.
+
+# Examples
+
+```julia
+m = Mutex([1, 2, 3])
+lock(m) do
+    @ref_into :mut arr2 = m[]
+    push!(arr2, 4)
+end
+```
+"""
+macro ref_into(expr::Expr)
+    is_borrow_checker_enabled(__module__) || return esc(expr)
+    return _ref_into(expr, false)
+end
+
+macro ref_into(mut_flag::QuoteNode, expr::Expr)
+    is_borrow_checker_enabled(__module__) || return esc(expr)
+    if mut_flag.value != :mut
+        error("First argument to @ref_into must be :mut")
+    end
+    return _ref_into(expr, true)
+end
+
+function _ref_into(expr::Expr, mut::Bool)
+    if !Meta.isexpr(expr, :(=))
+        error(
+            "@ref_into requires an assignment expression, " *
+            "e.g. `@ref_into :mut r = mutex[]`",
+        )
+    end
+    dest = expr.args[1]
+    src = expr.args[2]
+    return esc(:($dest = $(ref_into)($src, $(QuoteNode(dest)), Val($mut))))
 end
 
 """

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -344,19 +344,19 @@ end
 ```
 """
 macro ref_into(expr::Expr)
-    is_borrow_checker_enabled(__module__) || return esc(expr)
-    return _ref_into(expr, false)
+    enabled = is_borrow_checker_enabled(__module__)
+    return _ref_into(expr, false, enabled)
 end
 
 macro ref_into(mut_flag::QuoteNode, expr::Expr)
-    is_borrow_checker_enabled(__module__) || return esc(expr)
     if mut_flag.value != :mut
         error("First argument to @ref_into must be :mut")
     end
-    return _ref_into(expr, true)
+    enabled = is_borrow_checker_enabled(__module__)
+    return _ref_into(expr, true, enabled)
 end
 
-function _ref_into(expr::Expr, mut::Bool)
+function _ref_into(expr::Expr, mut::Bool, enabled::Bool)
     if !Meta.isexpr(expr, :(=))
         error(
             "@ref_into requires an assignment expression, " *
@@ -365,7 +365,7 @@ function _ref_into(expr::Expr, mut::Bool)
     end
     dest = expr.args[1]
     src = expr.args[2]
-    return esc(:($dest = $(ref_into)($src, $(QuoteNode(dest)), Val($mut))))
+    return esc(:($dest = $(ref_into)($src, $(QuoteNode(dest)), Val($mut), Val($enabled))))
 end
 
 """

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -23,7 +23,7 @@ Provides safe concurrent access to the protected value.
 ```julia
 m = Mutex([1, 2, 3])
 lock(m)
-@ref ~m :mut arr = m[]
+@ref_into :mut arr = m[]
 push!(arr, 4)
 unlock(m)
 ```
@@ -81,7 +81,7 @@ end
 function Base.showerror(io::IO, ::MutexGuardValueAccessError)
     print(io, "MutexGuardValueAccessError: ")
     print(io, "The mutex value must be accessed through a reference. ")
-    print(io, "For example, `@ref ~m [:mut] ref_var = m[]`.")
+    print(io, "For example, `@ref_into :mut ref_var = m[]`.")
     return nothing
 end
 
@@ -146,7 +146,7 @@ end
 
 A guard object that represents a locked mutex. 
 Created automatically when accessing a mutex's value with `m[]`.
-Use `@ref ~lt [:mut] ref_var = mutex_guard` to obtain a reference to the guarded value.
+Use `@ref_into [:mut] ref_var = mutex_guard` to obtain a reference to the guarded value.
 """
 struct MutexGuard{T,M<:AbstractMutex{T}}
     mutex::M

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -139,10 +139,8 @@ end
 Access the mutex for referencing. Must be used inside a lock block and with @ref.
 Throws a `LockNotHeldError` if the current task does not hold the lock.
 """
-function Base.getindex(m::AbstractMutex)
-    get_locked_by(m) !== current_task() && throw(LockNotHeldError())
-    return MutexGuard(m)
-end
+Base.getindex(m::AbstractMutex) = MutexGuard(m)
+# TODO: This MutexGuard shouldn't be passed when BorrowChecker is disabled
 
 # Overload ref for MutexGuard to create proper references
 function ref(

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -1,7 +1,7 @@
 module MutexModule
 
 using ..ErrorsModule: BorrowRuleError
-using ..TypesModule: OwnedMut, Lifetime, Borrowed, BorrowedMut
+using ..TypesModule: AllWrappers, OwnedMut, Lifetime, Borrowed, BorrowedMut
 using ..SemanticsModule: request_value, validate_mode, cleanup!
 
 import ..SemanticsModule: ref, own
@@ -37,6 +37,15 @@ mutable struct Mutex{T} <: AbstractMutex{T}
     function Mutex(value::T) where {T}
         owned_value = own(value, :anonymous, :anonymous, Val(true))
         return new{T}(owned_value, Threads.SpinLock(), nothing, nothing)
+    end
+    function Mutex(r::AllWrappers)
+        throw(
+            ArgumentError(
+                "Cannot create a Mutex around an object of type `$(typeof(r))`. " *
+                "Use `@take!` or `@take` to transfer ownership first, e.g.: " *
+                "`Mutex(@take!(value))` or `Mutex(@take(value))`",
+            ),
+        )
     end
 end
 

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -77,10 +77,13 @@ function Base.showerror(io::IO, ::MutexGuardValueAccessError)
 end
 
 function Base.show(io::IO, m::AbstractMutex{T}) where {T}
+    Base.lock(m)
     print(io, "Mutex{", T, "}(")
     value = request_value(unsafe_get_owner(m), Val(:read))
     show(io, value)
-    return print(io, ")")
+    print(io, ")")
+    Base.unlock(m)
+    return nothing
 end
 
 """

--- a/src/mutex.jl
+++ b/src/mutex.jl
@@ -1,8 +1,7 @@
 module MutexModule
 
 using ..ErrorsModule: BorrowRuleError
-using ..TypesModule:
-    Owned, OwnedMut, AbstractOwned, Lifetime, Borrowed, BorrowedMut, is_mutable
+using ..TypesModule: OwnedMut, Lifetime, Borrowed, BorrowedMut
 using ..SemanticsModule: request_value, validate_mode, cleanup!
 
 import ..SemanticsModule: ref, own
@@ -101,10 +100,6 @@ function Base.lock(m::AbstractMutex)
     m.lifetime = Lifetime()
     return m
 end
-function Base.lock(m_owned::Owned{<:AbstractMutex})
-    validate_mode(m_owned, Val(:read))
-    return lock(request_value(m_owned, Val(:read)))
-end
 
 """
     unlock(m::AbstractMutex)
@@ -118,10 +113,6 @@ function Base.unlock(m::AbstractMutex)
     m.locked_by = nothing
     Base.unlock(get_lock(m))
     return nothing
-end
-function Base.unlock(m_owned::Owned{<:AbstractMutex})
-    validate_mode(m_owned, Val(:read))
-    return unlock(request_value(m_owned, Val(:read)))
 end
 
 """

--- a/src/semantics.jl
+++ b/src/semantics.jl
@@ -143,6 +143,8 @@ function Base.show(io::IO, r::AllBorrowed)
     if is_moved(r)
         # TODO: I don't think we can ever get here?
         print(io, "[reference to moved value]")  # COV_EXCL_LINE
+    elseif is_expired(r)
+        print(io, "[expired reference]")
     else
         constructor = constructorof(typeof(r))
         value = request_value(r, Val(:read))

--- a/test/FakeModule/src/FakeModule.jl
+++ b/test/FakeModule/src/FakeModule.jl
@@ -1,7 +1,7 @@
 module FakeModule
 
 using BorrowChecker
-using BorrowChecker: @spawn
+using BorrowChecker: @spawn, LockNotHeldError
 using Test
 
 function test()
@@ -48,6 +48,16 @@ function test()
         # This spawn still works because the borrow checker is disabled
         @own x = 1
         @test fetch(@spawn x + 1) == 2
+    end
+
+    let
+        m = Mutex([1, 2, 3])
+        # Locking should still work:
+        @test_throws LockNotHeldError @ref_into :mut arr = m[]
+        @test !islocked(m)
+        lock(m)
+        @test islocked(m)
+        @ref_into :mut arr = m[]
     end
 end
 

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -132,3 +132,24 @@ end
     @test startswith(err_msg, "MutexMismatchError: ")
     @test occursin("must be the same", err_msg)
 end
+
+@testitem "Mutex show method" begin
+    using BorrowChecker
+
+    # Test showing a mutex with a simple value
+    m1 = Mutex(42)
+    output = sprint(show, m1)
+    @test output == "Mutex{Int64}(42)"
+
+    # Test showing a mutex with a more complex value
+    m2 = Mutex([1, 2, 3])
+    output = sprint(show, m2)
+    @test output == "Mutex{Vector{Int64}}([1, 2, 3])"
+
+    # Test showing a mutex with a composite type
+    m3 = Mutex((a=1, b="test"))
+    output = sprint(show, m3)
+    @test occursin("NamedTuple", output)
+    @test occursin("a = 1", output)
+    @test occursin("b = \"test\"", output)
+end

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -66,12 +66,16 @@ end
         @test_throws BorrowRuleError push!(arr_immut, 4)
     end
 
-    Base.@lock m begin
+    out = Base.@lock m begin
         # Create a mutable reference
         @ref ~m :mut arr_mut = m[]
         push!(arr_mut, 4)
         @test arr_mut == [1, 2, 3, 4]
+        arr_mut
     end
+    @test_throws ExpiredError push!(out, 5)
+    s = sprint(show, out)
+    @test s == "[expired reference]"
 end
 
 @testitem "Mutex error messages" begin

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -172,3 +172,23 @@ end
     @test trylock(m4) == true
     unlock(m4)
 end
+
+@testitem "Disallowed Mutex creation" begin
+    using BorrowChecker
+
+    # Create an owned value
+    @own owned_value = [1, 2, 3]
+
+    # Test that creating a Mutex with a wrapper throws the expected error
+    err = try
+        Mutex(owned_value)
+    catch e
+        e
+    end
+
+    @test err isa ArgumentError
+    err_msg = sprint(io -> showerror(io, err))
+    @test occursin(
+        "Cannot create a Mutex around an object of type `$(typeof(owned_value))`", err_msg
+    )
+end

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -152,4 +152,19 @@ end
     @test occursin("NamedTuple", output)
     @test occursin("a = 1", output)
     @test occursin("b = \"test\"", output)
+
+    # Test showing a locked mutex
+    m4 = Mutex(42)
+    try
+        lock(m4)
+        local output = sprint(show, m4)
+        @test output == "Mutex{Int64}([locked])"
+        @test trylock(m4) == false
+        @test islocked(m4) == true
+    finally
+        unlock(m4)
+    end
+    @test islocked(m4) == false
+    @test trylock(m4) == true
+    unlock(m4)
 end

--- a/test/mutex_tests.jl
+++ b/test/mutex_tests.jl
@@ -1,0 +1,85 @@
+using TestItems
+using BorrowChecker
+using Base.Threads: @spawn, Condition, ReentrantLock
+
+@testitem "Basic Mutex operations" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    # Create a mutex with a vector
+    m = Mutex([1, 2, 3])
+
+    # Verify we can access the mutex's value inside a lock
+    lock(m) do
+        @ref ~m :mut arr = m[]
+        @test arr == [1, 2, 3]
+        push!(arr, 4)
+    end
+
+    # Verify the value was modified
+    lock(m) do
+        @ref ~m arr = m[]
+        @test arr == [1, 2, 3, 4]
+    end
+
+    # Verify that we can't access the mutex outside a lock
+    @test_throws LockNotHeldError m[]
+end
+
+@testitem "Mutex with borrow checker enabled" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    # Create an owned value first, then move it into the mutex
+    @own data_to_protect = Dict(:counter => 0)
+    m = Mutex(@take!(data_to_protect))
+    # Mutexes don't need to be `@own`ed! They are safe
+    # to pass around as regular Julia objects.
+
+    # Modify the value safely through the mutex
+    Threads.@threads for _ in 1:10
+        lock(m) do
+            @ref ~m :mut dict = m[]
+            dict[:counter] += 1
+        end
+    end
+
+    # Verify the modification worked
+    lock(m) do
+        @ref ~m dict = m[]
+        @test dict[:counter] == 10
+    end
+end
+
+@testitem "Base.@lock syntax" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: LockNotHeldError
+
+    m = Mutex([1, 2, 3])
+
+    Base.@lock m begin
+        # Create an immutable reference
+        @ref ~m arr_immut = m[]
+        @test arr_immut == [1, 2, 3]
+
+        # We shouldn't be able to modify the immutable reference
+        @test_throws BorrowRuleError push!(arr_immut, 4)
+    end
+
+    Base.@lock m begin
+        # Create a mutable reference
+        @ref ~m :mut arr_mut = m[]
+        push!(arr_mut, 4)
+        @test arr_mut == [1, 2, 3, 4]
+    end
+end
+
+@testitem "Cannot own a mutex" begin
+    using BorrowChecker
+    using BorrowChecker.MutexModule: NoOwningMutexError
+
+    m = Mutex([1, 2, 3])
+
+    @test_throws NoOwningMutexError @own m_owned = m
+    @test_throws NoOwningMutexError @own :mut m_owned_mut = m
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("reference_tests.jl")
 include("feature_tests.jl")
 include("integration_tests.jl")
 include("complex_macros.jl")
+include("mutex_tests.jl")
 
 @testitem "Aqua" begin
     using Aqua


### PR DESCRIPTION
This creates a `Mutex` object for safe multi-threading. It's the same semantics as rust.

A Mutex object is safe to pass around in Julia, so there is no need to `@own` it. You access it with immutable and mutable references.

The lifetime of the references will be the duration the lock is held, after which, they will expire.

```julia
julia> m = Mutex([1, 2, 3])
       # ^Regular Julia assignment syntax is fine for Mutexes!
Mutex{Vector{Int64}}([1, 2, 3])

julia> lock(m);

julia> @ref_into :mut data = m[]
       # ^Mutable reference to the mutex-protected value
BorrowedMut{Vector{Int64},OwnedMut{Vector{Int64}}}([1, 2, 3], :data)

julia> push!(data, 4);

julia> unlock(m);

julia> m
Mutex{Vector{Int64}}([1, 2, 3, 4])

julia> data
[expired reference]
```