### PR TITLE
BREAKING CHANGE: make `@bc` default to immutable

### DIFF
--- a/src/semantics.jl
+++ b/src/semantics.jl
@@ -390,9 +390,13 @@ function maybe_ref(
     return ref(lt, val, var_symbol, Val(mut))
 end
 function maybe_ref(
-    ::Lifetime, val::Union{AllBorrowed,LazyAccessorOf{AllBorrowed}}, ::Symbol, ::Val{mut}=Val(false)
+    lt::Lifetime, val::Union{AllBorrowed,LazyAccessorOf{AllBorrowed}}, var_symbol::Symbol, ::Val{mut}=Val(false)
 ) where {mut}
-    return val
+    if is_mutable(val) == mut
+        return val
+    else
+        return ref(lt, val, var_symbol, Val(mut))
+    end
 end
 function maybe_ref(
     ::Lifetime, val, ::Symbol, ::Val{mut}=Val(false)

--- a/src/types.jl
+++ b/src/types.jl
@@ -341,8 +341,10 @@ const OrBorrowedMut{T} = Union{
 
 # Type-specific utilities
 # COV_EXCL_START
-is_mutable(r::AllMutable) = true
-is_mutable(r::AllImmutable) = false
+is_mutable(::Type{<:AllMutable}) = true
+is_mutable(::Type{<:AllImmutable}) = false
+is_mutable(::Type{<:LazyAccessorOf{T}}) where {T} = is_mutable(T)
+is_mutable(::T) where {T} = is_mutable(T)
 # COV_EXCL_STOP
 
 # Internal getters and setters


### PR DESCRIPTION
This breaking change makes the `@bc` macro default to immutable. Therefore, even for mutable references, they will be passed as immutable references _unless_ you say otherwise using the `@mut` macro.