### PR TITLE
fix LazyAccessor recursive `setproperty!(setindex!(...))`

### DIFF
--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -246,7 +246,7 @@ for op in (
     :float, :abs, :real, :imag, :conj, :transpose, :significand,
     :modf, :rem, :floor, :ceil, :round, :trunc,
     :inv, :sqrt, :cbrt, :abs2, :angle, :factorial,
-    :(!), :-, :+, :sign, :identity, :iszero, :isone,
+    :(!), :-, :+, :sign, :identity, :iszero, :isone, :isfinite, :isnan, :isinf,
     # Instantiation
     :signed, :unsigned, :widen, :prevfloat, :nextfloat,
     :one, :oneunit, :zero, :typemin, :typemax, :eps,

--- a/src/semantics.jl
+++ b/src/semantics.jl
@@ -124,7 +124,8 @@ end
 end
 @inline function Base.setproperty!(r::LazyAccessor, name::Symbol, value)
     target = getfield(r, :target)
-    setproperty!(request_value(target, Val(:write)), name, value)
+    validate_mode(target, Val(:write))
+    setproperty!(unsafe_access(r), name, value)
     return nothing
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -352,6 +352,12 @@ unsafe_get_value(r::OwnedMut) = getfield(r, :value)
 unsafe_get_value(r::Owned) = getfield(r, :value)
 unsafe_get_value(r::AllBorrowed) = getfield(r, :value)
 
+"""
+    unsafe_access(x::LazyAccessor)
+
+This recursively walks the parent chain of a LazyAccessor until it finds
+the raw target value.
+"""
 @inline function unsafe_access(x::LazyAccessor{T,<:Any,Val{property}}) where {T,property}
     parent = getfield(x, :parent)
     return getproperty(parent, property)::T


### PR DESCRIPTION
Also adds `isfinite`, `isnan`, `isinf` as overloads